### PR TITLE
Add adjustable electron orbits and data export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # AtomApp
 
 This app demonstrates a Bohr atomic model rendered with React Three Fiber. It uses Vite for bundling, Jotai for state, and MUI for UI components. Customize nucleus and electron sizes via props in the scene.
+
+## Features
+
+- Adjust the number of orbits and electrons per orbit in real time.
+- Control particle physics parameters such as gravity and speed.
+- Export particle positions to JSON for further analysis.

--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -3,20 +3,27 @@ import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import BohrAtom from './components/BohrAtom'
 import ParticleSystem from './components/ParticleSystem'
+import { useAtomValue } from 'jotai'
+import { orbitCountAtom, electronConfigAtom } from './state/atoms'
 
-const Scene: React.FC = () => (
-  <Canvas camera={{ position: [0, 5, 10], fov: 50 }}>
-    <ambientLight intensity={0.5} />
-    <pointLight position={[10, 10, 10]} />
-    <BohrAtom
-      orbitCount={3}
-      electronsPerOrbit={[2, 8, 1]}
-      nucleusRadius={0.5}
-      electronRadius={0.1}
-    />
-    <ParticleSystem particleRadius={0.05} />
-    <OrbitControls />
-  </Canvas>
-)
+const Scene: React.FC = () => {
+  const orbitCount = useAtomValue(orbitCountAtom)
+  const electronConfig = useAtomValue(electronConfigAtom)
+
+  return (
+    <Canvas camera={{ position: [0, 5, 10], fov: 50 }}>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <BohrAtom
+        orbitCount={orbitCount}
+        electronsPerOrbit={electronConfig}
+        nucleusRadius={0.5}
+        electronRadius={0.1}
+      />
+      <ParticleSystem particleRadius={0.05} />
+      <OrbitControls />
+    </Canvas>
+  )
+}
 
 export default Scene

--- a/src/components/UIControls.tsx
+++ b/src/components/UIControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useAtom } from 'jotai'
 import {
   Slider,
@@ -9,25 +9,47 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Button,
 } from '@mui/material'
 import {
   currentElectronOrbitAtom,
+  orbitCountAtom,
+  electronConfigAtom,
   particleCountAtom,
   forceMagnitudeAtom,
   simulationSpeedAtom,
   particleTypeAtom,
+  particleDataAtom,
 } from '../state/atoms'
 
 const UIControls: React.FC = () => {
   const [orbit, setOrbit] = useAtom(currentElectronOrbitAtom)
+  const [orbitCount, setOrbitCount] = useAtom(orbitCountAtom)
+  const [electronConfig, setElectronConfig] = useAtom(electronConfigAtom)
   const [particleCount, setParticleCount] = useAtom(particleCountAtom)
   const [force, setForce] = useAtom(forceMagnitudeAtom)
   const [speed, setSpeed] = useAtom(simulationSpeedAtom)
   const [type, setType] = useAtom(particleTypeAtom)
+  const [particleData] = useAtom(particleDataAtom)
 
   const handleOrbit = (_: Event, value: number | number[]) => {
     setOrbit(Array.isArray(value) ? value[0] : value)
   }
+
+  const handleOrbitCount = (_: Event, value: number | number[]) => {
+    const count = Array.isArray(value) ? value[0] : value
+    setOrbitCount(count)
+  }
+
+  const handleElectronCount =
+    (index: number) => (_: Event, value: number | number[]) => {
+      const newCount = Array.isArray(value) ? value[0] : value
+      setElectronConfig((prev) => {
+        const next = [...prev]
+        next[index] = newCount
+        return next
+      })
+    }
 
   const handleParticleCount = (_: Event, value: number | number[]) => {
     setParticleCount(Array.isArray(value) ? value[0] : value)
@@ -41,20 +63,92 @@ const UIControls: React.FC = () => {
     setSpeed(Array.isArray(value) ? value[0] : value)
   }
 
+  useEffect(() => {
+    setElectronConfig((prev) => {
+      const updated = prev.slice(0, orbitCount)
+      while (updated.length < orbitCount) {
+        updated.push(0)
+      }
+      return updated
+    })
+  }, [orbitCount, setElectronConfig])
+
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(particleData, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'particle-data.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <Paper sx={{ position: 'absolute', top: 16, left: 16, p: 2 }}>
-      <Stack spacing={2} width={220}>
-        <Typography>Electron Orbit: {orbit}</Typography>
-        <Slider value={orbit} min={1} max={3} step={1} onChange={handleOrbit} marks />
+      <Stack spacing={2} width={240}>
+        <Typography>Active Orbit: {orbit}</Typography>
+        <Slider
+          value={orbit}
+          min={1}
+          max={orbitCount}
+          step={1}
+          onChange={handleOrbit}
+          marks
+        />
+
+        <Typography>Orbit Count: {orbitCount}</Typography>
+        <Slider
+          value={orbitCount}
+          min={1}
+          max={3}
+          step={1}
+          onChange={handleOrbitCount}
+          marks
+        />
+
+        {Array.from({ length: orbitCount }).map((_, i) => (
+          <React.Fragment key={i}>
+            <Typography>
+              Electrons Orbit {i + 1}: {electronConfig[i]}
+            </Typography>
+            <Slider
+              value={electronConfig[i]}
+              min={0}
+              max={10}
+              step={1}
+              onChange={handleElectronCount(i)}
+            />
+          </React.Fragment>
+        ))}
 
         <Typography>Particle Count: {particleCount}</Typography>
-        <Slider value={particleCount} min={10} max={100} step={1} onChange={handleParticleCount} />
+        <Slider
+          value={particleCount}
+          min={10}
+          max={100}
+          step={1}
+          onChange={handleParticleCount}
+        />
 
         <Typography>Force Magnitude: {force}</Typography>
-        <Slider value={force} min={0} max={10} step={0.1} onChange={handleForce} />
+        <Slider
+          value={force}
+          min={0}
+          max={10}
+          step={0.1}
+          onChange={handleForce}
+        />
 
         <Typography>Simulation Speed: {speed}</Typography>
-        <Slider value={speed} min={0.1} max={5} step={0.1} onChange={handleSpeed} />
+        <Slider
+          value={speed}
+          min={0.1}
+          max={5}
+          step={0.1}
+          onChange={handleSpeed}
+        />
 
         <FormControl fullWidth>
           <InputLabel id="type-label">Particle</InputLabel>
@@ -69,6 +163,10 @@ const UIControls: React.FC = () => {
             <MenuItem value="neutral">Neutral</MenuItem>
           </Select>
         </FormControl>
+
+        <Button variant="contained" onClick={handleExport}>
+          Export Data
+        </Button>
       </Stack>
     </Paper>
   )

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,7 +1,8 @@
 import { atom } from 'jotai'
 
 export const currentElectronOrbitAtom = atom<number>(1)
-export const electronCountAtom = atom<number>(1)
+export const orbitCountAtom = atom<number>(3)
+export const electronConfigAtom = atom<number[]>([2, 8, 1])
 
 export interface ParticleData {
   position: [number, number, number]
@@ -9,7 +10,9 @@ export interface ParticleData {
 }
 
 export const particleCountAtom = atom<number>(50)
-export const particleTypeAtom = atom<'electron' | 'proton' | 'neutral'>('electron')
+export const particleTypeAtom = atom<'electron' | 'proton' | 'neutral'>(
+  'electron',
+)
 export const forceMagnitudeAtom = atom<number>(1)
 export const simulationSpeedAtom = atom<number>(1)
 export const particleDataAtom = atom<ParticleData[]>([])


### PR DESCRIPTION
## Summary
- add atoms to configure orbit count and electron configuration
- expose those settings in the scene and UI controls
- allow exporting particle simulation data to JSON
- document new features

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847853ed7c883259b51e091bbb3fe5d